### PR TITLE
Downgrade apt cookbook for vagrant's chef compatibility.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,6 @@
 site :opscode
 
-cookbook 'apt'
+cookbook 'apt', '~> 1.10'
 cookbook 'jenkins', git: 'git://github.com/opscode-cookbooks/jenkins.git'
 cookbook 'rvm', git: 'git://github.com/fnichol/chef-rvm.git'
 

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,0 +1,52 @@
+{
+  "sources": {
+    "apt": {
+      "locked_version": "1.10.0"
+    },
+    "jenkins": {
+      "locked_version": "0.8.0",
+      "git": "git://github.com/opscode-cookbooks/jenkins.git",
+      "ref": "0ff2a4e20e5ca0646a112b3bc11c22af87a9f3ad"
+    },
+    "rvm": {
+      "locked_version": "0.9.1",
+      "git": "git://github.com/fnichol/chef-rvm.git",
+      "ref": "7038fb8c518d0d7785767de215b1ae463f237973"
+    },
+    "runit": {
+      "locked_version": "1.1.0",
+      "git": "git://github.com/noazark/runit.git",
+      "ref": "31a6cf67fa376e89638381ae012bc7c5bc87b1bb"
+    },
+    "java": {
+      "locked_version": "1.12.0"
+    },
+    "windows": {
+      "locked_version": "1.10.0"
+    },
+    "chef_handler": {
+      "locked_version": "1.1.4"
+    },
+    "apache2": {
+      "locked_version": "1.6.6"
+    },
+    "nginx": {
+      "locked_version": "1.7.0"
+    },
+    "build-essential": {
+      "locked_version": "1.4.0"
+    },
+    "yum": {
+      "locked_version": "2.3.0"
+    },
+    "ohai": {
+      "locked_version": "1.1.10"
+    },
+    "iptables": {
+      "locked_version": "0.12.0"
+    },
+    "chef_gem": {
+      "locked_version": "0.1.0"
+    }
+  }
+}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,7 +38,7 @@ vagrant plugin install vagrant-berkshelf
 
 echo ""
 echo "Installing grunt using bundler"
-npm install grunt-cli -g
+sudo npm install grunt-cli -g
 
 echo ""
 echo "When there were no errors please try running 'vagrant up'"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -37,7 +37,7 @@ echo "Installing vagrant plugins"
 vagrant plugin install vagrant-berkshelf
 
 echo ""
-echo "Installing grunt using bundler"
+echo "Installing grunt using npm"
 sudo npm install grunt-cli -g
 
 echo ""


### PR DESCRIPTION
According to the apt's read me versions 1.8.2 to 1.10.0 depend on specific
Chef > 10.16.4 APIs. I suppose that for version 2.0 (current) the dependency is even
tighter, so I was testing and found that 1.10 completes the provisioning procedure
correctly, despite of being running chef 10.14.2, so I'm locking it to that version
on the Berksfile.
