### PR TITLE
Fix issue with installing grunt-cli.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,6 @@
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-nodeunit": "~0.1.2",
     "grunt-jenkins": "~0.2.0"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
Issue can be found at https://github.com/isaacs/npm/issues/3443, which I
ran into on my Mac machine. Adding this line allowed me to install
grunt-cli without issues.
